### PR TITLE
Force color when formatting log output as text

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 
 		switch c.String("log-format") {
 		case "text", "t":
-			logger.Formatter = new(logrus.TextFormatter)
+			logger.Formatter = &logrus.TextFormatter{ForceColors: true}
 		case "json", "j":
 			logger.Formatter = new(logrus.JSONFormatter)
 		default:


### PR DESCRIPTION
Otherwise the output is VERY difficult to read - if there are concerns
about using color when not attached to a tty, it is always possible to
use the json formatter (which does not have a forcecolors option)
