### PR TITLE
Not archiving jobs

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -18,5 +18,4 @@ type Conf struct {
 	GitHubSecret string
 	NoTravis     bool
 	NoGitHub     bool
-	SleepTime    int
 }

--- a/docs/enqueueing-a-build.md
+++ b/docs/enqueueing-a-build.md
@@ -19,7 +19,6 @@ curl -XPOST -H 'Content-Type: application/json' 'http://localhost:5000/docker-bu
 ```javascript
 {
   "account": "my-account",
-  "archived": "0001-01-01T00:00:00Z",
   "completed": "0001-01-01T00:00:00Z",
   "created": "2014-07-06T14:02:01.92446296-07:00",
   "id": "035c4ea0-d73b-5bde-7d6f-c806b04f2ec3",

--- a/docs/job-control.md
+++ b/docs/job-control.md
@@ -18,7 +18,6 @@ Example Response:
 ```javascript
 {
   "account": "modcloth",
-  "archived": "0001-01-01T00:00:00Z",
   "completed": "0001-01-01T00:00:00Z",
   "created": "2014-07-06T14:02:01.92446296-07:00",
   "id": "035c4ea0-d73b-5bde-7d6f-c806b04f2ec3",
@@ -45,7 +44,6 @@ Example Response:
 {
   "035c4ea0-d73b-5bde-7d6f-c806b04f2ec3": {
     "account": "modcloth",
-    "archived": "0001-01-01T00:00:00Z",
     "completed": "0001-01-01T00:00:00Z",
     "created": "2014-07-06T14:02:01.92446296-07:00",
     "id": "035c4ea0-d73b-5bde-7d6f-c806b04f2ec3",
@@ -72,7 +70,6 @@ Example Response:
 ```javascript
 {
   "account": "modcloth",
-  "archived": "0001-01-01T00:00:00Z",
   "completed": "0001-01-01T00:00:00Z",
   "created": "2014-07-06T14:02:01.92446296-07:00",
   "id": "035c4ea0-d73b-5bde-7d6f-c806b04f2ec3",

--- a/job/control.go
+++ b/job/control.go
@@ -2,7 +2,6 @@ package job
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"os/exec"
@@ -39,11 +38,6 @@ func TailN(params martini.Params, req *http.Request) (int, string) {
 
 func tailN(n, id string) (string, error) {
 	job := jobs[id]
-
-	if job.Status == "archived" {
-		return "", errors.New("job is archived, no log file available")
-	}
-
 	logFilePath := fmt.Sprintf("%s/log.log", job.logDir)
 	out, err := exec.Command("tail", "-n", n, logFilePath).Output()
 

--- a/main.go
+++ b/main.go
@@ -34,10 +34,6 @@ func init() {
 		conf.Config.Port = 5000
 	}
 
-	if conf.Config.SleepTime == 0 {
-		conf.Config.SleepTime = 600
-	}
-
 	// set logger defaults
 	Logger = logrus.New()
 	Logger.Formatter = &logrus.TextFormatter{ForceColors: true}
@@ -107,7 +103,6 @@ func main() {
 			Action:      func(c *cli.Context) { server.Logger(Logger); server.Serve(c) },
 			Flags: []cli.Flag{
 				cli.IntFlag{"port, p", conf.Config.Port, "port on which to serve"},
-				cli.IntFlag{"sleep-time", conf.Config.SleepTime, "sleep time, in seconds, before deleting log file"},
 				cli.StringFlag{"api-token, t", "", "GitHub API token"},
 				cli.BoolFlag{"skip-push", "override Bobfile behavior and do not push any images (useful for testing)"},
 				cli.StringFlag{"username", "", "username for basic auth"},

--- a/server/description.go
+++ b/server/description.go
@@ -8,7 +8,6 @@ Configure through the environment:
 DOCKER_BUILDER_LOGLEVEL             =>     --log-level (global)
 DOCKER_BUILDER_LOGFORMAT            =>     --log-format (global)
 DOCKER_BUILDER_PORT                 =>     --port
-DOCKER_BUILDER_SLEEPTIME            =>     --sleep-time
 DOCKER_BUILDER_APITOKEN             =>     --api-token
 DOCKER_BUILDER_SKIPPUSH             =>     --skip-push
 DOCKER_BUILDER_USERNAME             =>     --username

--- a/server/server.go
+++ b/server/server.go
@@ -63,8 +63,6 @@ func Serve(context *cli.Context) {
 		r.Get("", job.GetAll)
 	}, basicAuthFunc)
 
-	job.KeepLogTimeInSeconds = sleepTime
-
 	// start server
 	http.ListenAndServe(portString, server)
 }

--- a/server/vars.go
+++ b/server/vars.go
@@ -10,7 +10,7 @@ import (
 )
 
 var apiToken, githubSecret, portString, pwd, travisToken, un string
-var port, sleepTime int
+var port int
 var skipPush bool
 var shouldTravis, shouldGitHub bool
 var shouldBasicAuth, shouldTravisAuth, shouldGitHubAuth bool
@@ -30,7 +30,6 @@ func setVarsFromContext(c *cli.Context) {
 	travisToken = config.TravisToken
 	githubSecret = config.GitHubSecret
 	port = config.Port
-	sleepTime = config.SleepTime
 
 	// command line
 	cliUn := c.String("username")
@@ -39,11 +38,6 @@ func setVarsFromContext(c *cli.Context) {
 	cliTravisToken := c.String("travis-token")
 	cliGitHubSecret := c.String("github-secret")
 	cliPort := c.Int("port")
-	cliSleepTime := c.Int("sleep-time")
-
-	if cliSleepTime != config.SleepTime {
-		sleepTime = cliSleepTime
-	}
 
 	if cliTravisToken != "" {
 		travisToken = cliTravisToken


### PR DESCRIPTION
When archiving, the file ends up getting deleted before the job is actually done.  The result is that every incremental `docker push` log message after the file has been deleted (after the sleep period) adds a line to the logs like this:

``` text
Failed to write to log, write /tmp/docker-build-worker189515784/b0d01976-700c-47a5-6a7a-9f6ba5ff45b6/log.log: bad file descriptorFailed to write to log, write /tmp/docker-build-worker189515784/b0d01976-700c-47a5-6a7a-9f6ba5ff45b6/log.log: bad file descriptor
```

Rather than having that happen, I'm going to just remove archiving for now.  It can always be added back later if a need is discovered.

Ping @jszwedko 
