### PR TITLE
server: use custom logger function with blacklist

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/modcloth/docker-builder/builder"
 	"github.com/modcloth/docker-builder/job"
@@ -14,8 +15,10 @@ import (
 )
 
 var logger *logrus.Logger
-
-var server = martini.Classic()
+var server *martini.ClassicMartini
+var skipLogging = map[string]bool{
+	"/health": true,
+}
 
 //Logger sets the (global) logger for the server package
 func Logger(l *logrus.Logger) {
@@ -44,6 +47,9 @@ func Serve(context *cli.Context) {
 	// configure webhooks
 	webhook.Logger(logger)
 	webhook.APIToken(apiToken)
+
+	server = setupServer()
+
 	if shouldTravis {
 		server.Post("/docker-build/travis", travisAuthFunc, webhook.Travis)
 	}
@@ -65,4 +71,37 @@ func Serve(context *cli.Context) {
 
 	// start server
 	http.ListenAndServe(portString, server)
+}
+
+func setupServer() *martini.ClassicMartini {
+	router := martini.NewRouter()
+	server := martini.New()
+	server.Use(martini.Recovery())
+	server.Use(requestLogger)
+	server.MapTo(router, (*martini.Routes)(nil))
+	server.Action(router.Handle)
+	return &martini.ClassicMartini{server, router}
+}
+
+func requestLogger(res http.ResponseWriter, req *http.Request, c martini.Context) {
+	if skipLogging[req.URL.Path] {
+		return
+	}
+
+	start := time.Now()
+
+	addr := req.Header.Get("X-Real-IP")
+	if addr == "" {
+		addr = req.Header.Get("X-Forwarded-For")
+		if addr == "" {
+			addr = req.RemoteAddr
+		}
+	}
+
+	logger.Printf("Started %s %s for %s", req.Method, req.URL.Path, addr)
+
+	rw := res.(martini.ResponseWriter)
+	c.Next()
+
+	logger.Printf("Completed %v %s in %v\n", rw.Status(), http.StatusText(rw.Status()), time.Since(start))
 }


### PR DESCRIPTION
Fixes #85.

Also moves the route logging to logrus instead of log.Logger and turns off serving static files.
